### PR TITLE
fix: remove references to retro being "weekly"

### DIFF
--- a/.github/workflows/retro-generator.yml
+++ b/.github/workflows/retro-generator.yml
@@ -24,10 +24,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body: >
-            Here's a new weekly retro, automatically generated with
+            Here's a new retro, automatically generated with
             GitHub Actions and `@retrogen/generate`.
           branch: actions/retrogen  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate weekly retro'
-          title: 'doc: generate weekly retro'
+          commit-message: 'doc: generate retro'
+          title: 'doc: generate retro'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/retro-generator.yml` file to modify the automated retro generation process. The change includes modifying the body, commit message, and title associated with the retro generation from being specifically weekly to a more general retro. 

* [`.github/workflows/retro-generator.yml`](diffhunk://#diff-52b0e24170b6bf12f556457ffb0503b05a8bbff24bde04c229cabc603b80dc2cL27-R31): Modified the body, commit message, and title in the `jobs:` section to change from 'weekly retro' to 'retro', making the automated retro generation process more general and not time-specific.