### PR TITLE
chore: update checkout actions

### DIFF
--- a/.github/workflows/retro-generator.yml
+++ b/.github/workflows/retro-generator.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: run cloner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: run install
         run: npm install
       - name: run generator

--- a/.github/workflows/stale-repo-watchtower.yml
+++ b/.github/workflows/stale-repo-watchtower.yml
@@ -14,7 +14,7 @@ jobs:
         org: [twilio, twilio-labs]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run stale_repos tool
       uses: github/stale-repos@v1


### PR DESCRIPTION
<!-- Describe your Pull Request -->

updates the actions/checkout action to v4, since v3 seems to have required Node.js v16 which is now seemingly crashing the action.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
