### PR TITLE
ci: fix org metadata in contributor actions

### DIFF
--- a/.github/workflows/contributors-monthly-twilio-labs.yml
+++ b/.github/workflows/contributors-monthly-twilio-labs.yml
@@ -47,10 +47,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body: >
-            Here's a monthly contributor report for the Twilio organization,
+            Here's a monthly contributor report for the Twilio Labs organization,
             automatically generated with GitHub Actions.
           branch: actions/contributors  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate contributor report for the Twilio organization'
-          title: 'doc: generate contributor report for the Twilio organization'
+          commit-message: 'doc: generate contributor report for the Twilio Labs organization'
+          title: 'doc: generate contributor report for the Twilio Labs organization'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash

--- a/.github/workflows/contributors-monthly-twilio-samples.yml
+++ b/.github/workflows/contributors-monthly-twilio-samples.yml
@@ -47,10 +47,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body: >
-            Here's a monthly contributor report for the Twilio organization,
+            Here's a monthly contributor report for the Twilio Samples organization,
             automatically generated with GitHub Actions.
           branch: actions/contributors  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate contributor report for the Twilio organization'
-          title: 'doc: generate contributor report for the Twilio organization'
+          commit-message: 'doc: generate contributor report for the Twilio Samples organization'
+          title: 'doc: generate contributor report for the Twilio Samples organization'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash


### PR DESCRIPTION
fixes some incorrect metadata in the Contributor actions

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
