### PR TITLE
ci: remove blocking metrics from twilio-node issue metrics

### DIFF
--- a/.github/workflows/issue-metrics-twilio-node.yml
+++ b/.github/workflows/issue-metrics-twilio-node.yml
@@ -3,11 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'
-
-permissions:
-  issues: write
-  pull-requests: read
-
 jobs:
   build:
     name: Issue Metrics (twilio-node)


### PR DESCRIPTION
removes a permissions block that was blocking twilio-node issue metrics from running.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
