### PR TITLE
fix: also convert stale_repos.json

### DIFF
--- a/reports/watchtower/json/README.md
+++ b/reports/watchtower/json/README.md
@@ -1,0 +1,3 @@
+# Stale Repository Watchtower, but JSON
+
+This directory contains JSON source files for the markdown we store in the directory above. There's not a specific intent behind keeping these other than it being nice to retain the data for analysis down the road and it not being too much additional work to do so.

--- a/utilities/watchtower/stale-repo.js
+++ b/utilities/watchtower/stale-repo.js
@@ -3,6 +3,7 @@ const convertToFileWithDate = require('../helpers/convertToFileWithDate')
 async function convertContributors () {
   try {
     await convertToFileWithDate('./stale_repos.md', './reports/watchtower', 'stale')
+    await convertToFileWithDate('./stale_repos.json', './reports/watchtower/json', 'stale')
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
Apparently the stale repos tooling also creates a data file, so let's store that just because we can.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
