### PR TITLE
fix: use a dedicated watchtower branch for the watchtower action

### DIFF
--- a/.github/workflows/stale-repo-watchtower.yml
+++ b/.github/workflows/stale-repo-watchtower.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         body: >
           Monthly Watchtower report, automatically generated with GitHub Actions.
-        branch: actions/metrics  # Custom branch *just* for this Action.
+        branch: actions/watchtower  # Custom branch *just* for this Action.
         commit-message: 'doc: generate watchtower report'
         title: 'doc: generate watchtower report'
         assignees: bnb # change to whoever you want to be assigned to this PR


### PR DESCRIPTION
Switches to using a dedicated branch for the watchtower action, so we don't mess up the metrics PRs.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
