### PR TITLE
fix: split all mutlifaceted actions into individual actions

### DIFF
--- a/.github/workflows/retro-sendgrid.yml
+++ b/.github/workflows/retro-sendgrid.yml
@@ -1,0 +1,33 @@
+name: Generate Retro (SendGrid)
+on:
+  schedule:
+    # Run once a week at 00:00 AM UTC on Sunday.
+    - cron: 0 0 * * 0
+  # Run on demand via the GitHub UI
+  workflow_dispatch:
+
+jobs:
+  generate_retro:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run npm install
+        run: npm install
+      - name: Run npm run retro:sendgrid
+        run: npm run retro:sendgrid # Run the generation tools
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run gr2m/create-or-update-pull-request
+        uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: >
+            Here's a new retro, automatically generated with
+            GitHub Actions and `@retrogen/generate`.
+          branch: actions/retrogen  # Custom branch *just* for this Action.
+          commit-message: 'doc: generate retro'
+          title: 'doc: generate retro'
+          assignees: bnb # change to whoever you want to be assigned to this PR
+          auto-merge: squash

--- a/.github/workflows/retro-sendgrid.yml
+++ b/.github/workflows/retro-sendgrid.yml
@@ -27,7 +27,7 @@ jobs:
             Here's a new retro, automatically generated with
             GitHub Actions and `@retrogen/generate`.
           branch: actions/retrogen  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate retro'
+          commit-message: 'doc: generate sendgrid retro'
           title: 'doc: generate retro'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash

--- a/.github/workflows/retro-twilio-labs.yml
+++ b/.github/workflows/retro-twilio-labs.yml
@@ -1,0 +1,33 @@
+name: Generate Retro (Twilio Labs)
+on:
+  schedule:
+    # Run once a week at 00:00 AM UTC on Sunday.
+    - cron: 0 0 * * 0
+  # Run on demand via the GitHub UI
+  workflow_dispatch:
+
+jobs:
+  generate_retro:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run npm install
+        run: npm install
+      - name: Run npm run retro:twilio-labs
+        run: npm run retro:twilio-labs # Run the generation tools
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run gr2m/create-or-update-pull-request
+        uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: >
+            Here's a new retro, automatically generated with
+            GitHub Actions and `@retrogen/generate`.
+          branch: actions/retrogen  # Custom branch *just* for this Action.
+          commit-message: 'doc: generate retro'
+          title: 'doc: generate retro'
+          assignees: bnb # change to whoever you want to be assigned to this PR
+          auto-merge: squash

--- a/.github/workflows/retro-twilio-labs.yml
+++ b/.github/workflows/retro-twilio-labs.yml
@@ -27,7 +27,7 @@ jobs:
             Here's a new retro, automatically generated with
             GitHub Actions and `@retrogen/generate`.
           branch: actions/retrogen  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate retro'
+          commit-message: 'doc: generate twilio-labs retro'
           title: 'doc: generate retro'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash

--- a/.github/workflows/retro-twilio-samples.yml
+++ b/.github/workflows/retro-twilio-samples.yml
@@ -1,0 +1,33 @@
+name: Generate Retro (Twilio Samples)
+on:
+  schedule:
+    # Run once a week at 00:00 AM UTC on Sunday.
+    - cron: 0 0 * * 0
+  # Run on demand via the GitHub UI
+  workflow_dispatch:
+
+jobs:
+  generate_retro:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run npm install
+        run: npm install
+      - name: Run npm run retro:twilio-samples
+        run: npm run retro:twilio-samples # Run the generation tools
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run gr2m/create-or-update-pull-request
+        uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: >
+            Here's a new retro, automatically generated with
+            GitHub Actions and `@retrogen/generate`.
+          branch: actions/retrogen  # Custom branch *just* for this Action.
+          commit-message: 'doc: generate retro'
+          title: 'doc: generate retro'
+          assignees: bnb # change to whoever you want to be assigned to this PR
+          auto-merge: squash

--- a/.github/workflows/retro-twilio-samples.yml
+++ b/.github/workflows/retro-twilio-samples.yml
@@ -27,7 +27,7 @@ jobs:
             Here's a new retro, automatically generated with
             GitHub Actions and `@retrogen/generate`.
           branch: actions/retrogen  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate retro'
+          commit-message: 'doc: generate twilio-samples retro'
           title: 'doc: generate retro'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash

--- a/.github/workflows/retro-twilio.yml
+++ b/.github/workflows/retro-twilio.yml
@@ -27,7 +27,7 @@ jobs:
             Here's a new retro, automatically generated with
             GitHub Actions and `@retrogen/generate`.
           branch: actions/retrogen  # Custom branch *just* for this Action.
-          commit-message: 'doc: generate retro'
+          commit-message: 'doc: generate twilio retro'
           title: 'doc: generate retro'
           assignees: bnb # change to whoever you want to be assigned to this PR
           auto-merge: squash

--- a/.github/workflows/retro-twilio.yml
+++ b/.github/workflows/retro-twilio.yml
@@ -1,4 +1,4 @@
-name: Generate Retro
+name: Generate Retro (Twilio)
 on:
   schedule:
     # Run once a week at 00:00 AM UTC on Sunday.
@@ -10,15 +10,15 @@ jobs:
   generate_retro:
     runs-on: ubuntu-latest
     steps:
-      - name: run cloner
+      - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: run install
+      - name: Run npm install
         run: npm install
-      - name: run generator
-        run: npm run generate # Run the generation tools
+      - name: Run npm run retro:twilio
+        run: npm run retro:twilio # Run the generation tools
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: run create/update pull request
+      - name: Run gr2m/create-or-update-pull-request
         uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-repo-watchtower-twilio-labs.yml
+++ b/.github/workflows/stale-repo-watchtower-twilio-labs.yml
@@ -1,0 +1,40 @@
+name: Stale Repo Watchtower (Twilio Labs)
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+jobs:
+  build:
+    name: Stale Repo Watchtower
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run stale-repos Tool
+      uses: github/stale-repos@v1
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ORGANIZATION: twilio-labs
+        INACTIVE_DAYS: 182
+        ACTIVITY_METHOD: "pushed"
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'latest'
+    - name: Update npm
+      run: npm install -g npm
+    - name: Install Dependencies
+      run: npm install
+    - name: Move Watchtower Report File to Storage
+      run: npm run convert:watchtower:twilio-labs
+    - name: Run gr2m/create-or-update-pull-request
+      uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        body: >
+          Monthly Watchtower report, automatically generated with GitHub Actions.
+        branch: actions/watchtower  # Custom branch *just* for this Action.
+        commit-message: 'doc: generate watchtower report'
+        title: 'doc: generate watchtower report'
+        assignees: bnb # change to whoever you want to be assigned to this PR
+        auto-merge: squash

--- a/.github/workflows/stale-repo-watchtower-twilio-samples.yml
+++ b/.github/workflows/stale-repo-watchtower-twilio-samples.yml
@@ -1,0 +1,40 @@
+name: Stale Repo Watchtower (Twilio Samples)
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+jobs:
+  build:
+    name: Stale Repo Watchtower
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run stale-repos Tool
+      uses: github/stale-repos@v1
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ORGANIZATION: twilio-samples
+        INACTIVE_DAYS: 182
+        ACTIVITY_METHOD: "pushed"
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'latest'
+    - name: Update npm
+      run: npm install -g npm
+    - name: Install Dependencies
+      run: npm install
+    - name: Move Watchtower Report File to Storage
+      run: npm run convert:watchtower:twilio-samples
+    - name: Run gr2m/create-or-update-pull-request
+      uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        body: >
+          Monthly Watchtower report, automatically generated with GitHub Actions.
+        branch: actions/watchtower  # Custom branch *just* for this Action.
+        commit-message: 'doc: generate watchtower report'
+        title: 'doc: generate watchtower report'
+        assignees: bnb # change to whoever you want to be assigned to this PR
+        auto-merge: squash

--- a/.github/workflows/stale-repo-watchtower-twilio.yml
+++ b/.github/workflows/stale-repo-watchtower-twilio.yml
@@ -1,4 +1,4 @@
-name: Stale Repo Watchtower
+name: Stale Repo Watchtower (Twilio)
 on:
   workflow_dispatch:
   schedule:
@@ -7,16 +7,13 @@ jobs:
   build:
     name: Stale Repo Watchtower
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        org: [twilio, twilio-labs, twilio-samples]
     steps:
     - uses: actions/checkout@v4
     - name: Run stale-repos Tool
       uses: github/stale-repos@v1
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ORGANIZATION: ${{ matrix.org }}
+        ORGANIZATION: twilio
         INACTIVE_DAYS: 182
         ACTIVITY_METHOD: "pushed"
     - name: Setup Node.js
@@ -28,7 +25,7 @@ jobs:
     - name: Install Dependencies
       run: npm install
     - name: Move Watchtower Report File to Storage
-      run: npm run convert:watchtower
+      run: npm run convert:watchtower:twilio
     - name: Run gr2m/create-or-update-pull-request
       uses: gr2m/create-or-update-pull-request-action@v1 # Create a PR or update the Action's existing PR
       env: 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "Utilities for collecting public information about the public Twilio GitHub organizations",
   "scripts": {
-    "retros": "npm run retro:twilio && npm run retro:twilio-labs && npm run retro:twilio-samples && npm run retro:sendgrid",
     "retro:twilio": "node utilities/retros/twilio.js",
     "retro:twilio-labs": "node utilities/retros/twilio-labs.js",
     "retro:twilio-samples": "node utilities/retros/twilio-samples.js",
@@ -26,7 +25,9 @@
     "convert:metrics:twilio-go": "node utilities/metrics/twilio-go",
     "convert:metrics:twilio-ruby": "node utilities/metrics/twilio-ruby",
     "convert:metrics:twilio-cli": "node utilities/metrics/twilio-cli",
-    "convert:watchtower": "node utilities/watchtower/stale-repo"
+    "convert:watchtower:twilio": "node utilities/watchtower/twilio",
+    "convert:watchtower:twilio-labs": "node utilities/watchtower/twilio-labs",
+    "convert:watchtower:twilio-samples": "node utilities/watchtower/twilio-samples"
   },
   "author": "Tierney Cyren <tcyren@twilio.com> (https://twilio.com)",
   "license": "MIT",

--- a/utilities/watchtower/twilio-labs.js
+++ b/utilities/watchtower/twilio-labs.js
@@ -1,0 +1,12 @@
+const convertToFileWithDate = require('../helpers/convertToFileWithDate')
+
+async function convertContributors () {
+  try {
+    await convertToFileWithDate('./stale_repos.md', './reports/watchtower', 'twilio-labs')
+    await convertToFileWithDate('./stale_repos.json', './reports/watchtower/json', 'twilio-labs')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+convertContributors()

--- a/utilities/watchtower/twilio-samples.js
+++ b/utilities/watchtower/twilio-samples.js
@@ -1,0 +1,12 @@
+const convertToFileWithDate = require('../helpers/convertToFileWithDate')
+
+async function convertContributors () {
+  try {
+    await convertToFileWithDate('./stale_repos.md', './reports/watchtower', 'twilio-samples')
+    await convertToFileWithDate('./stale_repos.json', './reports/watchtower/json', 'twilio-samples')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+convertContributors()

--- a/utilities/watchtower/twilio.js
+++ b/utilities/watchtower/twilio.js
@@ -2,8 +2,8 @@ const convertToFileWithDate = require('../helpers/convertToFileWithDate')
 
 async function convertContributors () {
   try {
-    await convertToFileWithDate('./stale_repos.md', './reports/watchtower', 'stale')
-    await convertToFileWithDate('./stale_repos.json', './reports/watchtower/json', 'stale')
+    await convertToFileWithDate('./stale_repos.md', './reports/watchtower', 'twilio')
+    await convertToFileWithDate('./stale_repos.json', './reports/watchtower/json', 'twilio')
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
This PR does a couple things:

- Fixes the broken retros Action (it was calling a now removed script)
- Splits the retros Action into individual Actions, so if one fails but the others don't... we still get something
- Splits the watchtower Action into multiple Actions so we don't hit secondary rate limits (lol) and so the files don't overwrite each other.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
