### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/contributors-monthly-twilio-labs.yml
+++ b/.github/workflows/contributors-monthly-twilio-labs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Contributor Action
-        uses: github/contributors@v1
+        uses: github-community-projects/contributors@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}

--- a/.github/workflows/contributors-monthly-twilio-samples.yml
+++ b/.github/workflows/contributors-monthly-twilio-samples.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Contributor Action
-        uses: github/contributors@v1
+        uses: github-community-projects/contributors@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}

--- a/.github/workflows/contributors-monthly-twilio.yml
+++ b/.github/workflows/contributors-monthly-twilio.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Contributor Action
-        uses: github/contributors@v1
+        uses: github-community-projects/contributors@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}

--- a/.github/workflows/issue-metrics-sendgrid-csharp.yml
+++ b/.github/workflows/issue-metrics-sendgrid-csharp.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-csharp is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-sendgrid-go.yml
+++ b/.github/workflows/issue-metrics-sendgrid-go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-go is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-sendgrid-java.yml
+++ b/.github/workflows/issue-metrics-sendgrid-java.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-java is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-sendgrid-nodejs.yml
+++ b/.github/workflows/issue-metrics-sendgrid-nodejs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-nodejs is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-sendgrid-php.yml
+++ b/.github/workflows/issue-metrics-sendgrid-php.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-php is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-sendgrid-python.yml
+++ b/.github/workflows/issue-metrics-sendgrid-python.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-python is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-sendgrid-ruby.yml
+++ b/.github/workflows/issue-metrics-sendgrid-ruby.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:sendgrid/sendgrid-ruby is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-cli.yml
+++ b/.github/workflows/issue-metrics-twilio-cli.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-cli is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-csharp.yml
+++ b/.github/workflows/issue-metrics-twilio-csharp.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-csharp is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-go.yml
+++ b/.github/workflows/issue-metrics-twilio-go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-go is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-java.yml
+++ b/.github/workflows/issue-metrics-twilio-java.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-java is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-node.yml
+++ b/.github/workflows/issue-metrics-twilio-node.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-node is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-php.yml
+++ b/.github/workflows/issue-metrics-twilio-php.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-php is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-python.yml
+++ b/.github/workflows/issue-metrics-twilio-python.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-python is:issue created:${{ env.last_month }}'

--- a/.github/workflows/issue-metrics-twilio-ruby.yml
+++ b/.github/workflows/issue-metrics-twilio-ruby.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run issue-metrics Tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:twilio/twilio-ruby is:issue created:${{ env.last_month }}'

--- a/.github/workflows/stale-repo-watchtower-twilio-labs.yml
+++ b/.github/workflows/stale-repo-watchtower-twilio-labs.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run stale-repos Tool
-      uses: github/stale-repos@v1
+      uses: github-community-projects/stale-repos@v1
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ORGANIZATION: twilio-labs

--- a/.github/workflows/stale-repo-watchtower-twilio-samples.yml
+++ b/.github/workflows/stale-repo-watchtower-twilio-samples.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run stale-repos Tool
-      uses: github/stale-repos@v1
+      uses: github-community-projects/stale-repos@v1
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ORGANIZATION: twilio-samples

--- a/.github/workflows/stale-repo-watchtower-twilio.yml
+++ b/.github/workflows/stale-repo-watchtower-twilio.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run stale-repos Tool
-      uses: github/stale-repos@v1
+      uses: github-community-projects/stale-repos@v1
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ORGANIZATION: twilio


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/contributors` | `github-community-projects/contributors` |
| `github/issue-metrics` | `github-community-projects/issue-metrics` |
| `github/stale-repos` | `github-community-projects/stale-repos` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
